### PR TITLE
[Feature] Creating get all orders by customer id endpoint

### DIFF
--- a/src/main/java/br/com/pinkgreen/mkt/controller/OrderController.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/OrderController.java
@@ -3,21 +3,27 @@ package br.com.pinkgreen.mkt.controller;
 import br.com.pinkgreen.mkt.controller.exception.InvalidCustomerIdException;
 import br.com.pinkgreen.mkt.controller.model.CheckoutOrderResponse;
 import br.com.pinkgreen.mkt.controller.model.OrderRequest;
+import br.com.pinkgreen.mkt.controller.model.OrderResponse;
 import br.com.pinkgreen.mkt.controller.translator.OrderRequestMapperImpl;
+import br.com.pinkgreen.mkt.controller.translator.OrderResponseMapperImpl;
 import br.com.pinkgreen.mkt.domain.OrderDomain;
 import br.com.pinkgreen.mkt.usecase.CheckoutOrderUseCase;
+import br.com.pinkgreen.mkt.usecase.GetAllOrdersByCustomerIdUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -27,6 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 public class OrderController implements OrderControllerApi {
 
     private final CheckoutOrderUseCase checkoutOrderUseCase;
+    private final GetAllOrdersByCustomerIdUseCase getAllOrdersByCustomerIdUseCase;
 
     @Override
     @SneakyThrows
@@ -34,7 +41,9 @@ public class OrderController implements OrderControllerApi {
     @RolesAllowed("user")
     public ResponseEntity<CheckoutOrderResponse> checkout(OrderRequest orderRequest, HttpServletRequest request) {
         log.info("[CONTROLLER] Receiving new order request");
-        getCustomerIdAndValidate((KeycloakAuthenticationToken) request.getUserPrincipal(), orderRequest);
+        String customerId = orderRequest.getCustomerData().getId();
+
+        getCustomerIdAndValidate((KeycloakAuthenticationToken) request.getUserPrincipal(), customerId);
 
         var orderDomain = new OrderRequestMapperImpl().orderRequestToOrder(orderRequest);
         OrderDomain orderCreated = checkoutOrderUseCase.execute(orderDomain, orderDomain.getPaymentData());
@@ -45,10 +54,25 @@ public class OrderController implements OrderControllerApi {
                 .build());
     }
 
-    private void getCustomerIdAndValidate(KeycloakAuthenticationToken keycloakAuthenticationToken, OrderRequest orderRequest) throws InvalidCustomerIdException {
-        String customerId = keycloakAuthenticationToken.getAccount().getKeycloakSecurityContext().getToken().getSubject();
+    @Override
+    @SneakyThrows
+    @GetMapping("/{customerId}")
+    @RolesAllowed("user")
+    public ResponseEntity<List<OrderResponse>> getOrdersByCustomerId(String customerId, HttpServletRequest request) {
+        getCustomerIdAndValidate((KeycloakAuthenticationToken) request.getUserPrincipal(), customerId);
 
-        if (!orderRequest.getCustomerData().getId().equals(customerId)) {
+        List<OrderDomain> orders = getAllOrdersByCustomerIdUseCase.execute(customerId);
+
+        List<OrderResponse> orderResponses = orders.stream().map(new OrderResponseMapperImpl()::orderToOrderResponse).collect(Collectors.toList());
+
+        return ResponseEntity.ok(orderResponses);
+    }
+
+
+    private void getCustomerIdAndValidate(KeycloakAuthenticationToken keycloakAuthenticationToken, String customerId) throws InvalidCustomerIdException {
+        String tokenCustomerId = keycloakAuthenticationToken.getAccount().getKeycloakSecurityContext().getToken().getSubject();
+
+        if (!customerId.equals(tokenCustomerId)) {
             throw new InvalidCustomerIdException("[CONTROLLER] Invalid customerId");
         }
     }

--- a/src/main/java/br/com/pinkgreen/mkt/controller/OrderControllerApi.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/OrderControllerApi.java
@@ -2,19 +2,18 @@ package br.com.pinkgreen.mkt.controller;
 
 import br.com.pinkgreen.mkt.controller.model.CheckoutOrderResponse;
 import br.com.pinkgreen.mkt.controller.model.OrderRequest;
+import br.com.pinkgreen.mkt.controller.model.OrderResponse;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import java.util.List;
 
 public interface OrderControllerApi {
 
-    @PostMapping
-    @RolesAllowed("user")
     @ApiOperation(value = "Criação de pedido")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
@@ -27,4 +26,18 @@ public interface OrderControllerApi {
             @ApiResponse(code = 500, message = "Erro de servidor"),
     })
     ResponseEntity<CheckoutOrderResponse> checkout(@Valid @RequestBody OrderRequest orderRequest, HttpServletRequest request);
+
+
+    @ApiOperation(value = "Retorna todos os pedidos de um cliente")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "Authorization", value = "Access Token", required = true, paramType = "header", dataTypeClass = String.class, example = "Bearer access_token")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Lista de todas as compras registradas deste cliente"),
+            @ApiResponse(code = 401, message = "Você não possui credenciais válidas para acessar este recurso, portanto será necessário autenticar-se novamente"),
+            @ApiResponse(code = 403, message = "Você não tem permissão para acessar este recurso"),
+            @ApiResponse(code = 422, message = "Erro de validação"),
+            @ApiResponse(code = 500, message = "Erro de servidor"),
+    })
+    ResponseEntity<List<OrderResponse>> getOrdersByCustomerId(@ApiParam(value = "ID do cliente", required = true, example = "1f508dc081fd6db15d1d9056e457cd3f") @PathVariable String customerId, HttpServletRequest request);
 }

--- a/src/main/java/br/com/pinkgreen/mkt/controller/model/AddressRequest.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/model/AddressRequest.java
@@ -44,6 +44,11 @@ public class AddressRequest {
     @ApiModelProperty(value = "CEP de entrega", required = true, example = "13480-180")
     private String zipcode;
 
+    @NotBlank(message = "Street must not be blank")
+    @Length(min = 2, max = 60, message = "Street must have between 2 and 60 characters")
+    @ApiModelProperty(value = "Rua de entrega", required = true, example = "R. Boa Morte")
+    private String street;
+
     @NotNull
     @Length(max = 100, message = "Complement must have between 2 and 100 characters")
     @ApiModelProperty(value = "Complemento do endereço", required = true, example = "AP 190")

--- a/src/main/java/br/com/pinkgreen/mkt/controller/model/AddressResponse.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/model/AddressResponse.java
@@ -1,0 +1,40 @@
+package br.com.pinkgreen.mkt.controller.model;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class AddressResponse {
+
+    @ApiModelProperty(value = "Cidade de entrega", required = true, example = "Limeira")
+    private String city;
+
+    @ApiModelProperty(value = "Estado de entrega", required = true, example = "SP")
+    private String state;
+
+    @ApiModelProperty(value = "País de entrega", required = true, example = "Brasil")
+    private String country;
+
+    @ApiModelProperty(value = "Bairro de entrega", required = true, example = "Centro")
+    private String neighborhood;
+
+    @ApiModelProperty(value = "CEP de entrega", required = true, example = "13480-180")
+    private String zipcode;
+
+    @ApiModelProperty(value = "Rua de entrega", required = true, example = "R. Boa Morte")
+    private String street;
+
+    @ApiModelProperty(value = "Complemento do endereço", required = true, example = "AP 190")
+    private String complement;
+
+    @ApiModelProperty(value = "Complemento do endereço", required = true, example = "380")
+    private String number;
+
+    @ApiModelProperty(value = "Numero de contato", required = true, example = "+55 (19) 99999-9999")
+    private String phone;
+}

--- a/src/main/java/br/com/pinkgreen/mkt/controller/model/CustomerResponse.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/model/CustomerResponse.java
@@ -1,0 +1,32 @@
+package br.com.pinkgreen.mkt.controller.model;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class CustomerResponse {
+
+
+    @ApiModelProperty(value = "ID do cliente", required = true, example = "1f508dc081fd6db15d1d9056e457cd3f")
+    private String id;
+
+    @ApiModelProperty(value = "Primeiro nome do cliente", required = true, example = "Elza")
+    private String name;
+
+    @ApiModelProperty(value = "Sobrenome do cliente", required = true, example = "Luna Rocha")
+    private String lastname;
+
+    @ApiModelProperty(value = "CPF do cliente", required = true, example = "947.229.723-46")
+    private String document;
+
+    @ApiModelProperty(value = "E-mail do cliente", required = true, example = "test@test.com.br")
+    private String email;
+
+    @ApiModelProperty(value = "Número de telefone do cliente", required = true, example = "+55 (19) 99999-9999")
+    private String phone;
+}

--- a/src/main/java/br/com/pinkgreen/mkt/controller/model/OrderResponse.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/model/OrderResponse.java
@@ -1,0 +1,37 @@
+package br.com.pinkgreen.mkt.controller.model;
+
+import br.com.pinkgreen.mkt.domain.enums.OrderStatus;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class OrderResponse {
+
+    @ApiModelProperty(value = "Número do pedido", example = "1036920")
+    private String id;
+
+    @ApiModelProperty(value = "Status atual do pedido")
+    private OrderStatus status;
+
+    private CustomerResponse customerData;
+
+    private ShippingDataResponse shippingData;
+
+    private List<ProductResponse> productList;
+
+    private PaymentDataResponse paymentData;
+
+    @ApiModelProperty(value = "Data de criação do pedido")
+    private Instant createdAt;
+
+    @ApiModelProperty(value = "Data da ultima atualização do pedido")
+    private Instant updatedAt;
+}

--- a/src/main/java/br/com/pinkgreen/mkt/controller/model/PaymentDataResponse.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/model/PaymentDataResponse.java
@@ -1,0 +1,19 @@
+package br.com.pinkgreen.mkt.controller.model;
+
+import br.com.pinkgreen.mkt.domain.enums.PaymentMethod;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class PaymentDataResponse {
+
+    @ApiModelProperty(value = "Preço total da compra", required = true, example = "9900.99")
+    private Double amount;
+    private PaymentMethod paymentMethod;
+    private AddressResponse paymentAddress;
+}

--- a/src/main/java/br/com/pinkgreen/mkt/controller/model/ProductResponse.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/model/ProductResponse.java
@@ -1,0 +1,25 @@
+package br.com.pinkgreen.mkt.controller.model;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class ProductResponse {
+
+    @ApiModelProperty(value = "SKU do produto", required = true, example = "888888888")
+    private String sku;
+
+    @ApiModelProperty(value = "Nome do produto", required = true, example = "Samsung Galaxy S21 Cinza")
+    private String name;
+
+    @ApiModelProperty(value = "Preço do produto", required = true, example = "3859.90")
+    private Double price;
+
+    @ApiModelProperty(value = "Quantidade do estoque do produto", required = true, example = "1000")
+    private Integer quantity;
+}

--- a/src/main/java/br/com/pinkgreen/mkt/controller/model/ShippingDataResponse.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/model/ShippingDataResponse.java
@@ -1,0 +1,21 @@
+package br.com.pinkgreen.mkt.controller.model;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class ShippingDataResponse {
+
+    @ApiModelProperty(value = "Preço da taxa de frete", required = true, example = "18.90")
+    private Double freightPrice;
+
+    @ApiModelProperty(value = "Dias úteis para entrega do pedido", required = true, example = "3")
+    private Integer deliveryDays;
+
+    private AddressResponse address;
+}

--- a/src/main/java/br/com/pinkgreen/mkt/controller/translator/OrderResponseMapper.java
+++ b/src/main/java/br/com/pinkgreen/mkt/controller/translator/OrderResponseMapper.java
@@ -1,0 +1,14 @@
+package br.com.pinkgreen.mkt.controller.translator;
+
+import br.com.pinkgreen.mkt.controller.model.OrderResponse;
+import br.com.pinkgreen.mkt.domain.OrderDomain;
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface OrderResponseMapper {
+
+    OrderDomain orderResponseToOrder(OrderResponse orderRequest);
+
+    OrderResponse orderToOrderResponse(OrderDomain orderDomain);
+
+}

--- a/src/main/java/br/com/pinkgreen/mkt/gateway/GetAllOrdersByCustomerIdGateway.java
+++ b/src/main/java/br/com/pinkgreen/mkt/gateway/GetAllOrdersByCustomerIdGateway.java
@@ -1,0 +1,10 @@
+package br.com.pinkgreen.mkt.gateway;
+
+import br.com.pinkgreen.mkt.domain.OrderDomain;
+
+import java.util.List;
+
+public interface GetAllOrdersByCustomerIdGateway {
+
+    List<OrderDomain> execute(String customerId);
+}

--- a/src/main/java/br/com/pinkgreen/mkt/gateway/postgresql/GetAllOrdersByCustomerIdGatewayImpl.java
+++ b/src/main/java/br/com/pinkgreen/mkt/gateway/postgresql/GetAllOrdersByCustomerIdGatewayImpl.java
@@ -1,0 +1,25 @@
+package br.com.pinkgreen.mkt.gateway.postgresql;
+
+import br.com.pinkgreen.mkt.domain.OrderDomain;
+import br.com.pinkgreen.mkt.gateway.GetAllOrdersByCustomerIdGateway;
+import br.com.pinkgreen.mkt.gateway.postgresql.model.OrderDatabase;
+import br.com.pinkgreen.mkt.gateway.postgresql.translator.OrderDatabaseMapperImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class GetAllOrdersByCustomerIdGatewayImpl implements GetAllOrdersByCustomerIdGateway {
+
+    private final OrderRepository orderRepository;
+
+    @Override
+    public List<OrderDomain> execute(String customerId) {
+        List<OrderDatabase> ordersDatabase = orderRepository.findAllOrdersByCustomerId(customerId);
+
+        return ordersDatabase.stream().map(new OrderDatabaseMapperImpl()::orderDatabaseToOrder).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/br/com/pinkgreen/mkt/gateway/postgresql/OrderRepository.java
+++ b/src/main/java/br/com/pinkgreen/mkt/gateway/postgresql/OrderRepository.java
@@ -2,9 +2,15 @@ package br.com.pinkgreen.mkt.gateway.postgresql;
 
 import br.com.pinkgreen.mkt.gateway.postgresql.model.OrderDatabase;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface OrderRepository extends JpaRepository<OrderDatabase, Integer> {
 
+    @Query(value = "SELECT * FROM order_database WHERE customer_data ->> 'id' = :customerId", nativeQuery = true)
+    List<OrderDatabase> findAllOrdersByCustomerId(@Param("customerId") String customerId);
 }

--- a/src/main/java/br/com/pinkgreen/mkt/usecase/GetAllOrdersByCustomerIdUseCase.java
+++ b/src/main/java/br/com/pinkgreen/mkt/usecase/GetAllOrdersByCustomerIdUseCase.java
@@ -1,0 +1,19 @@
+package br.com.pinkgreen.mkt.usecase;
+
+import br.com.pinkgreen.mkt.domain.OrderDomain;
+import br.com.pinkgreen.mkt.gateway.GetAllOrdersByCustomerIdGateway;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GetAllOrdersByCustomerIdUseCase {
+
+    private final GetAllOrdersByCustomerIdGateway getAllOrdersByCustomerIdGateway;
+
+    public List<OrderDomain> execute(String customerId) {
+        return getAllOrdersByCustomerIdGateway.execute(customerId);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,10 +1,7 @@
 spring:
-  jpa:
-    database: POSTGRESQL
-    hibernate:
-      ddl-auto: create
-  database:
-    driverClassName: org.postgresql.Driver
+#    hibernate:
+#      ddl-auto: create
+#    show-sql: true
   datasource:
     url: jdbc:postgresql://localhost:5432/pinkgreen_mkt
     username: local
@@ -22,8 +19,11 @@ spring:
       bindings:
         process-order-payment-output:
           destination: process-order-payment
+          group: internal.process-order-payment
         process-order-payment-input:
           destination: process-order-payment
+          group: internal.process-order-payment
+
 keycloak:
   realm: Pinkgreen-mkt
   auth-server-url: http://localhost:8180/auth


### PR DESCRIPTION
Criado endpoint para recuperar todas as compras de um cliente.

Neste PR foi feito:
  - A criação dos modelos de response para poder fazer toda a documentação deste endpoint utilizando o nosso Swagger (Idêntico ao que tinhamos feito anteriormente).
  - A criação de um use case e gateway para recuperar todos os pedidos de um único cliente por Customer ID.
    - Para poder filtrar todos os pedidos de um único cliente foi criado um novo método na interface `OrderRepository` chamado `findAllOrdersByCustomerId` no qual utiliza de uma query nativa para fazer o select no PostgreSQL utilizando o JSONB.